### PR TITLE
Add more fields to refresh definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@schibstedspain/openads-connector-api",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "OpenAds Interfaces to be compliant developing a new OpenAds connector",
   "main": "dist/",
   "scripts": {

--- a/src/interface/AdViewable.js
+++ b/src/interface/AdViewable.js
@@ -14,10 +14,13 @@ export default class AdViewable {
   /**
    * Returns and empty Promise when the refresh operation has finished
    * @param {string} id The unique identifier of the position
-   * @param {segmentation} segmentation Data to be updated for the position
+   * @param {string} placement
+   * @param {Array<Array<number,number>>} sizes
+   * @param {string} segmentation
+   * @param {Object} native - Fields requested to the ad server
    * @returns {Promise} Promise object representing when the operation finish
    */
-  refresh ({domElementId, segmentation}) {
+  refresh ({domElementId, placement, sizes, segmentation, native}) {
     throw new Error('AdViewable#refresh must be implemented')
   }
 }


### PR DESCRIPTION
* the segmentation concept in AdLoadable interface is different to placement, sizes, native
* the AdViewable interface should enable refreshes of all loadable fields (excepting id)

![](https://media.giphy.com/media/zcLcgT7NKQAFy/giphy.gif)